### PR TITLE
add role-aware login and registration flow with custom authenticator

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,14 +4,19 @@ security:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
-        users_in_memory: { memory: null }
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
+            custom_authenticators:
+                - App\Security\LoginFormAuthenticator
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,12 @@ services:
       - "${APP_PORT:-8000}:80"
     environment:
       APP_ENV: ${APP_ENV:-dev}
-      APP_SECRET: ${APP_SECRET:-secret}
+      APP_SECRET: ${APP_SECRET:-257d6c7206d4ad40592e1f0a760a3fcc}
       MYSQL_HOST: db
       MYSQL_PORT: 3306
       MYSQL_DATABASE: ${MYSQL_DATABASE:-qwepic}
       MYSQL_USER: ${MYSQL_USER:-qwepic}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-secret}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-qweqwe}
       MYSQL_VERSION: ${MYSQL_VERSION:-8.0.36}
     restart: unless-stopped
 
@@ -27,10 +27,10 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     environment:
-      MYSQL_ROOT_PASSWORD: rootsecret
+      MYSQL_ROOT_PASSWORD: rootqwe
       MYSQL_DATABASE: qwepic
       MYSQL_USER: qwepic
-      MYSQL_PASSWORD: secret
+      MYSQL_PASSWORD: qweqwe
     ports:
       - "${DB_PORT:-13306}:3306"
 
@@ -44,7 +44,7 @@ services:
     environment:
       PMA_HOST: db
       PMA_USER: ${MYSQL_USER:-qwepic}
-      PMA_PASSWORD: ${MYSQL_PASSWORD:-secret}
+      PMA_PASSWORD: ${MYSQL_PASSWORD:-qweqwe}
 
 volumes:
   db_data:

--- a/migrations/Version20251003045231.php
+++ b/migrations/Version20251003045231.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251003045231 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE role (
+            id INT AUTO_INCREMENT NOT NULL,
+            name VARCHAR(50) NOT NULL,
+            UNIQUE INDEX UNIQ_57698A6A5E237E06 (name),
+            PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('CREATE TABLE user (
+            id INT AUTO_INCREMENT NOT NULL,
+            role_id INT NOT NULL,
+            email VARCHAR(255) NOT NULL,
+            password_hash VARCHAR(255) NOT NULL,
+            created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+            updated_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+            UNIQUE INDEX UNIQ_8D93D649E7927C74 (email),
+            INDEX IDX_8D93D649D60322AC (role_id),
+            PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE user ADD CONSTRAINT FK_8D93D649D60322AC FOREIGN KEY (role_id) REFERENCES role (id)');
+
+        $this->addSql('CREATE TABLE messenger_messages (
+            id BIGINT AUTO_INCREMENT NOT NULL,
+            body LONGTEXT NOT NULL,
+            headers LONGTEXT NOT NULL,
+            queue_name VARCHAR(190) NOT NULL,
+            created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+            available_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+            delivered_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\',
+            INDEX IDX_75EA56E0FB7336F0 (queue_name),
+            INDEX IDX_75EA56E0E3BD61CE (available_at),
+            INDEX IDX_75EA56E016BA31DB (delivered_at),
+            PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+}

--- a/migrations/Version20251003053726.php
+++ b/migrations/Version20251003053726.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251003053726 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user CHANGE email email VARCHAR(50) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user CHANGE email email VARCHAR(255) NOT NULL');
+    }
+}

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -2,7 +2,12 @@
 
 namespace App\Controller;
 
+use App\Entity\User;
+use App\Form\RegistrationFormType;
+use App\Form\LoginFormType;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -13,25 +18,56 @@ final class SecurityController extends AbstractController
     #[Route('/login', name: 'app_login')]
     public function login(AuthenticationUtils $authenticationUtils, Request $request): Response
     {
-        $error = $authenticationUtils->getLastAuthenticationError();
+        $form = $this->createForm(LoginFormType::class);
+        $form->handleRequest($request);
 
+        $error = $authenticationUtils->getLastAuthenticationError();
         $lastUsername = $authenticationUtils->getLastUsername();
 
         return $this->render('security/login.html.twig', [
+            'loginForm' => $form->createView(),
             'last_username' => $lastUsername,
             'error' => $error,
         ]);
     }
 
     #[Route('/register', name: 'app_register')]
-    public function register(Request $request): Response
+    public function register(Request $request, EntityManagerInterface $em): Response
     {
-        if ($request->isMethod('POST')) {
-            $this->addFlash('success', 'Registration successful! Please log in.');
-            return $this->redirectToRoute('app_login');
+        $user = new User();
+        $form = $this->createForm(RegistrationFormType::class, $user);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // Check if email already exists
+            $existingUser = $em->getRepository(User::class)->findOneBy(['email' => $user->getEmail()]);
+            if ($existingUser) {
+                $form->get('email')->addError(new FormError('This email is already registered.'));
+            } else {
+                // Get plain password from unmapped field
+                $plainPassword = $form->get('password')->getData();
+                $hashedPassword = password_hash($plainPassword, PASSWORD_DEFAULT);
+                $user->setPasswordHash($hashedPassword);
+
+                // Get role entity directly from form (EntityType)
+                $role = $form->get('role')->getData();
+                $user->setRole($role);
+
+                $user->setCreatedAt(new \DateTimeImmutable());
+                $user->setUpdatedAt(new \DateTimeImmutable());
+
+                $em->persist($user);
+                $em->flush();
+
+                $this->addFlash('success', 'Registration successful! Please log in.');
+                return $this->redirectToRoute('app_login');
+            }
         }
 
-        return $this->render('security/register.html.twig');
+        return $this->render('security/register.html.twig', [
+            'registrationForm' => $form->createView(),
+        ]);
     }
 
     #[Route('/logout', name: 'app_logout')]

--- a/src/Entity/Role.php
+++ b/src/Entity/Role.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\RoleRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: RoleRepository::class)]
+class Role
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 50, unique: true)]
+    private ?string $name = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\UserRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+class User implements UserInterface, PasswordAuthenticatedUserInterface
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 50, unique: true)]
+    private ?string $email = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $passwordHash = null;
+
+    #[ORM\Column]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\Column]
+    private ?\DateTimeImmutable $updatedAt = null;
+
+    #[ORM\ManyToOne(targetEntity: Role::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Role $role = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): static
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->passwordHash;
+    }
+
+    public function getPasswordHash(): ?string
+    {
+        return $this->passwordHash;
+    }
+
+    public function setPasswordHash(string $passwordHash): static
+    {
+        $this->passwordHash = $passwordHash;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): static
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): static
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getRole(): ?Role
+    {
+        return $this->role;
+    }
+
+    public function setRole(?Role $role): static
+    {
+        $this->role = $role;
+        return $this;
+    }
+
+    public function getRoles(): array
+    {
+        $roles = ['ROLE_USER'];
+
+        if ($this->role && $this->role->getName()) {
+            $roleName = $this->role->getName();
+            if (!str_starts_with($roleName, 'ROLE_')) {
+                $roleName = 'ROLE_' . strtoupper($roleName);
+            }
+            $roles[] = $roleName;
+        }
+
+        return array_values(array_unique($roles));
+    }
+
+    public function eraseCredentials(): void
+    {
+        // No temporary sensitive data stored on the entity.
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return (string) $this->email;
+    }
+}

--- a/src/Form/LoginFormType.php
+++ b/src/Form/LoginFormType.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class LoginFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('_username', EmailType::class, [
+                'label' => 'Email',
+                'label_attr' => [
+                    'class' => 'block font-inter font-semibold text-sm text-space-cadet mb-2',
+                ],
+                'attr' => [
+                    'class' => 'w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white font-inter text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10',
+                    'placeholder' => 'Enter your email',
+                ],
+            ])
+            ->add('password', PasswordType::class, [
+                'label' => 'Password',
+                'label_attr' => [
+                    'class' => 'block font-inter font-semibold text-sm text-space-cadet mb-2',
+                ],
+                'attr' => [
+                    'class' => 'w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white font-inter text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10',
+                    'placeholder' => 'Enter your password',
+                ],
+            ])
+            ->add('remember_me', CheckboxType::class, [
+                'label'    => 'Remember me',
+                'required' => false,
+                'label_attr' => [
+                    'class' => 'flex items-center font-inter text-sm text-slate-gray cursor-pointer',
+                ],
+                'attr' => [
+                    'class' => 'w-4 h-4 mr-3 accent-accent-coral',
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            // No data_class for login form
+        ]);
+    }
+}

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use App\Entity\Role;
+use App\Entity\User;
+
+class RegistrationFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('email', EmailType::class, [
+                'label' => 'Email',
+                'label_attr' => [
+                    'class' => 'block font-semibold text-sm text-space-cadet mb-2 font-sans',
+                ],
+                'attr' => [
+                    'class' => 'w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10 font-sans',
+                    'placeholder' => 'Enter your email',
+                ],
+            ])
+            ->add('password', PasswordType::class, [
+                'label' => 'Password',
+                'mapped' => false,
+                'label_attr' => [
+                    'class' => 'block font-semibold text-sm text-space-cadet mb-2 font-sans',
+                ],
+                'attr' => [
+                    'class' => 'w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10 font-sans',
+                    'placeholder' => 'Create a strong password',
+                ],
+            ])
+            ->add('role', EntityType::class, [
+                'label' => 'Role',
+                'label_attr' => [
+                    'class' => 'block font-semibold text-sm text-space-cadet mb-2 font-sans',
+                ],
+                'class' => Role::class,
+                'choice_label' => 'name',
+                'attr' => [
+                    'class' => 'w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white text-base text-space-cadet transition duration-300 focus:outline-none cursor-pointer focus:ring-1 font-sans',
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/src/Repository/RoleRepository.php
+++ b/src/Repository/RoleRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Role;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Role>
+ */
+class RoleRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Role::class);
+    }
+
+    //    /**
+    //     * @return Role[] Returns an array of Role objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('r')
+    //            ->andWhere('r.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('r.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?Role
+    //    {
+    //        return $this->createQueryBuilder('r')
+    //            ->andWhere('r.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<User>
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+
+    //    /**
+    //     * @return User[] Returns an array of User objects
+    //     */
+    //    public function findByExampleField($value): array
+    //    {
+    //        return $this->createQueryBuilder('u')
+    //            ->andWhere('u.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->orderBy('u.id', 'ASC')
+    //            ->setMaxResults(10)
+    //            ->getQuery()
+    //            ->getResult()
+    //        ;
+    //    }
+
+    //    public function findOneBySomeField($value): ?User
+    //    {
+    //        return $this->createQueryBuilder('u')
+    //            ->andWhere('u.exampleField = :val')
+    //            ->setParameter('val', $value)
+    //            ->getQuery()
+    //            ->getOneOrNullResult()
+    //        ;
+    //    }
+}

--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+
+class LoginFormAuthenticator extends AbstractLoginFormAuthenticator
+{
+    public const LOGIN_ROUTE = 'app_login';
+
+    private RouterInterface $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $formData = $request->request->all('login_form');
+
+        $email = (string) ($formData['_username'] ?? '');
+        $password = (string) ($formData['password'] ?? '');
+        $csrfToken = (string) ($formData['_token'] ?? '');
+
+        if ($request->hasSession()) {
+            $request->getSession()->set('_security.last_username', $email);
+        }
+
+        $rememberMeBadge = new RememberMeBadge();
+        if (!empty($formData['remember_me'])) {
+            $rememberMeBadge->enable();
+        }
+
+        return new Passport(
+            new UserBadge($email),
+            new PasswordCredentials($password),
+            [
+                new CsrfTokenBadge('authenticate', $csrfToken),
+                $rememberMeBadge,
+            ]
+        );
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?RedirectResponse
+    {
+        /** @var \App\Entity\User $user */
+        $user = $token->getUser();
+
+        // If Photographer, redirect to home page
+        if ($user->getRole() && $user->getRole()->getName() === 'Photographer') {
+            return new RedirectResponse($this->router->generate('app_home'));
+        }
+
+        // Otherwise, redirect to homepage (change as needed)
+        return new RedirectResponse($this->router->generate('app_home'));
+    }
+
+    protected function getLoginUrl(Request $request): string
+    {
+        return $this->router->generate(self::LOGIN_ROUTE);
+    }
+}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -3,16 +3,20 @@
 {% block title %}QwePic - Login{% endblock %}
 
 {% block body %}
-<div class="min-h-screen bg-anti-flash-white flex items-center justify-center p-8 font-sans">
-    <div class="bg-white rounded-2xl shadow-elevated w-full max-w-md overflow-hidden">
+<div class="min-h-screen bg-anti-flash-white flex items-center justify-center p-8 font-inter">
+    <div class="bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden">
         <!-- QwePic Logo -->
         <div class="text-center p-8 bg-gradient-to-br from-gray-50 to-gray-100">
-            <img src="{{ asset('images/logo-light.svg') }}" alt="QwePic Logo" class="w-32 h-auto mx-auto">
+            <img src="{{ asset('images/logo-plain.svg') }}" alt="QwePic Logo" class="w-32 h-auto mx-auto">
         </div>
 
         <!-- Login Form -->
         <div class="p-8">
-            <h1 class="font-heading font-bold text-3xl text-space-cadet text-center mb-6">Login</h1>
+            <h1 class="font-poppins font-bold text-3xl text-space-cadet text-center mb-6">Login</h1>
+
+            <div class="text-center mb-8">
+                <p class="text-slate-gray text-sm leading-relaxed">Welcome back! Please log in to your account.</p>
+            </div>
 
             {% if error %}
                 <div class="p-4 rounded-lg mb-6 bg-red-50 text-red-700 border border-red-200">
@@ -26,49 +30,39 @@
                 </div>
             {% endfor %}
 
-            <form method="post" class="w-full">
-                <!-- Email Field -->
+            {{ form_start(loginForm, {'attr': {'class': 'w-full'}}) }}
                 <div class="mb-6">
-                    <label for="username" class="block font-sans font-semibold text-sm text-space-cadet mb-2">Email</label>
-                    <input type="email" id="username" name="email"
-                        class="w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white font-sans text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10"
-                        value="{{ last_username }}" required autocomplete="email" autofocus>
+                    {{ form_row(loginForm._username) }}
                 </div>
-
-                <!-- Password Field -->
                 <div class="mb-6">
-                    <label for="password" class="block font-sans font-semibold text-sm text-space-cadet mb-2">Password</label>
-                    <input type="password" id="password" name="password"
-                        class="w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white font-sans text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10"
-                        required autocomplete="current-password">
+                    {{ form_row(loginForm.password) }}
                 </div>
-
-                <!-- Remember Me -->
-                <div class="mb-4">
-                    <label for="remember_me" class="flex items-center font-sans text-sm text-slate-gray cursor-pointer">
-                        <input type="checkbox" id="remember_me" name="_remember_me" class="w-4 h-4 mr-3 accent-accent-coral">
-                        Remember me
-                    </label>
+                <div class="mb-4 flex items-center justify-between">
+                    <div class="flex items-center">
+                        {{ form_widget(loginForm.remember_me, {
+                            'attr': {
+                                'class': 'w-4 h-4 accent-accent-coral cursor-pointer'
+                            }
+                        }) }}
+                        {{ form_label(loginForm.remember_me, null, {
+                            'label_attr': {
+                                'class': 'ml-2 font-inter text-sm text-slate-gray cursor-pointer'
+                            }
+                        }) }}
+                    </div>
                 </div>
-
-                <!-- Forgot Password Link -->
                 <div class="mb-6 text-center">
                     <a href="#" class="text-slate-gray text-sm transition duration-300 hover:text-accent-coral">Forgot Password?</a>
                 </div>
-
-                <!-- Submit Button -->
                 <button type="submit"
-                    class="w-full p-4 bg-accent-coral text-anti-flash-white font-sans font-semibold text-base rounded-lg cursor-pointer transition duration-300 hover:bg-red-400 mb-6">
+                        class="w-full p-4 bg-accent-coral text-anti-flash-white font-inter font-semibold text-base rounded-lg cursor-pointer transition duration-300 hover:bg-red-400 mb-6">
                     Log In
                 </button>
-            </form>
+            {{ form_end(loginForm) }}
 
             <!-- Switch to Register -->
             <div class="text-center pt-6 border-t border-gray-200">
-                <p class="text-slate-gray text-sm">
-                    Don't have an account?
-                    <a href="{{ path('app_register') }}" class="text-vivid-sky-blue font-semibold transition duration-300 hover:text-blue-400">Sign up here</a>
-                </p>
+                <p class="text-slate-gray text-sm">Don't have an account? <a href="{{ path('app_register') }}" class="text-vivid-sky-blue font-semibold transition duration-300 hover:text-blue-400">Sign up here</a></p>
             </div>
         </div>
     </div>

--- a/templates/security/register.html.twig
+++ b/templates/security/register.html.twig
@@ -7,7 +7,7 @@
     <div class="bg-white rounded-2xl shadow-elevated w-full max-w-md overflow-hidden">
         <!-- QwePic Logo -->
         <div class="text-center p-8 bg-gradient-to-br from-gray-50 to-gray-100">
-            <img src="{{ asset('images/logo-light.svg') }}" alt="QwePic Logo" class="w-32 h-auto mx-auto">
+            <img src="{{ asset('images/logo-plain.svg') }}" alt="QwePic Logo" class="w-32 h-auto mx-auto">
         </div>
 
         <!-- Sign Up Form -->
@@ -24,44 +24,20 @@
                 </div>
             {% endfor %}
 
-            <form method="post" class="w-full">
-                <!-- Name Field -->
+            {{ form_start(registrationForm, {'attr': {'class': 'w-full'}}) }}
                 <div class="mb-6">
-                    <label for="name" class="block font-semibold text-sm text-space-cadet mb-2 font-sans">Full Name</label>
-                    <input type="text" id="name" name="name"
-                           class="w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10 font-sans"
-                           required autocomplete="name">
+                    {{ form_row(registrationForm.email) }}
                 </div>
-
-                <!-- Email Field -->
                 <div class="mb-6">
-                    <label for="email" class="block font-semibold text-sm text-space-cadet mb-2 font-sans">Email</label>
-                    <input type="email" id="email" name="email"
-                           class="w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10 font-sans"
-                           required autocomplete="email">
+                    {{ form_row(registrationForm.password) }}
                 </div>
-
-                <!-- Password Field -->
                 <div class="mb-6">
-                    <label for="password" class="block font-semibold text-sm text-space-cadet mb-2 font-sans">Password</label>
-                    <input type="password" id="password" name="password"
-                           class="w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10 font-sans"
-                           required autocomplete="new-password" minlength="6">
+                    {{ form_row(registrationForm.role) }}
                 </div>
-
-                <!-- Confirm Password Field -->
-                <div class="mb-6">
-                    <label for="confirm_password" class="block font-semibold text-sm text-space-cadet mb-2 font-sans">Confirm Password</label>
-                    <input type="password" id="confirm_password" name="confirm_password"
-                           class="w-full px-4 py-3 border-2 border-slate-gray rounded-lg bg-anti-flash-white text-base text-space-cadet transition duration-300 focus:outline-none focus:border-vivid-sky-blue focus:ring-2 focus:ring-vivid-sky-blue/10 font-sans"
-                           required autocomplete="new-password" minlength="6">
-                </div>
-
-                <!-- Terms Agreement -->
                 <div class="mb-6">
                     <label for="agree_terms" class="flex items-start text-sm text-slate-gray cursor-pointer font-sans">
                         <input type="checkbox" id="agree_terms" name="agree_terms"
-                               class="w-4 h-4 mr-3 mt-0.5 accent-accent-coral" required>
+                               class="w-4 h-4 mr-3 mt-0.5 accent-accent-coral cursor-pointer" required>
                         <span>
                             I agree to the
                             <a href="#" class="text-vivid-sky-blue hover:text-blue-400 transition duration-300">Terms of Service</a>
@@ -70,13 +46,11 @@
                         </span>
                     </label>
                 </div>
-
-                <!-- Submit Button -->
                 <button type="submit"
                         class="w-full p-4 bg-accent-coral text-anti-flash-white font-semibold text-base rounded-lg cursor-pointer transition duration-300 hover:bg-red-400 mb-6 font-sans">
                     Sign Up
                 </button>
-            </form>
+            {{ form_end(registrationForm) }}
 
             <!-- Switch to Login -->
             <div class="text-center pt-6 border-t border-gray-200">


### PR DESCRIPTION
- configure security to use the custom login authenticator backed by the [User](`cci:2://file:///d:/Projects/qwepic/qwepic-dev/src/Entity/User.php:9:0-126:1`) entity provider
- build Tailwind-styled registration and login forms with role selection and remember-me checkbox
- implement [User](`cci:2://file:///d:/Projects/qwepic/qwepic-dev/src/Entity/User.php:9:0-126:1`) and [Role](`cci:2://file:///d:/Projects/qwepic/qwepic-dev/src/Entity/Role.php:7:0-34:1`) entities, repositories, migrations, and authenticator logic supporting hashed passwords and redirects

Closes #4 